### PR TITLE
Support PDF/A return format

### DIFF
--- a/src/Validator/ReturnFormat.php
+++ b/src/Validator/ReturnFormat.php
@@ -33,6 +33,7 @@ class ReturnFormat extends FileExtension
             'DOCX',
             'HTML',
             'PDF',
+            'PDFA',
             'RTF',
             'TX',
         ];


### PR DESCRIPTION
Trying to use PDF/A as a return format resulted in a validation error.